### PR TITLE
feat: enable rss message foward by setting gotify token

### DIFF
--- a/init.php
+++ b/init.php
@@ -197,7 +197,7 @@ class gotify_notifications extends Plugin {
 			$token = $app_tokens[$feed_id];
 		}
 
-		if (in_array($feed_id, $enabled_feeds)) {
+		if (strlen($token) > 0) {
 			if ($this->isNewArticle($article['guid_hashed']) === true) {
 				$this->sendMessage(
 					Feeds::_get_title($feed_id),


### PR DESCRIPTION
这里token是否为空是判断开启gotify转发的依据，可以在插件的全局设置中控制token达到全局rss消息的转发，然后控制单个rss的token调控单个rss的转发； debian上游更新订阅是需要默认全部开启的，这里只需要在插件的全局设置中添加token开启